### PR TITLE
Resolve item differing measurement types bug

### DIFF
--- a/app/assets/javascripts/measurements.coffee
+++ b/app/assets/javascripts/measurements.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/measurements.scss
+++ b/app/assets/stylesheets/measurements.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Measurements controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/measurements_controller.rb
+++ b/app/controllers/measurements_controller.rb
@@ -1,0 +1,74 @@
+class MeasurementsController < ApplicationController
+  before_action :set_measurement, only: [:show, :edit, :update, :destroy]
+
+  # GET /measurements
+  # GET /measurements.json
+  def index
+    @measurements = Measurement.all
+  end
+
+  # GET /measurements/1
+  # GET /measurements/1.json
+  def show
+  end
+
+  # GET /measurements/new
+  def new
+    @measurement = Measurement.new
+  end
+
+  # GET /measurements/1/edit
+  def edit
+  end
+
+  # POST /measurements
+  # POST /measurements.json
+  def create
+    @measurement = Measurement.new(measurement_params)
+
+    respond_to do |format|
+      if @measurement.save
+        format.html { redirect_to @measurement, notice: 'Measurement was successfully created.' }
+        format.json { render :show, status: :created, location: @measurement }
+      else
+        format.html { render :new }
+        format.json { render json: @measurement.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /measurements/1
+  # PATCH/PUT /measurements/1.json
+  def update
+    respond_to do |format|
+      if @measurement.update(measurement_params)
+        format.html { redirect_to @measurement, notice: 'Measurement was successfully updated.' }
+        format.json { render :show, status: :ok, location: @measurement }
+      else
+        format.html { render :edit }
+        format.json { render json: @measurement.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /measurements/1
+  # DELETE /measurements/1.json
+  def destroy
+    @measurement.destroy
+    respond_to do |format|
+      format.html { redirect_to measurements_url, notice: 'Measurement was successfully destroyed.' }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+    def set_measurement
+      @measurement = Measurement.find(params[:id])
+    end
+
+    # Never trust parameters from the scary internet, only allow the white list through.
+    def measurement_params
+      params.require(:measurement).permit(:unit)
+    end
+end

--- a/app/helpers/measurements_helper.rb
+++ b/app/helpers/measurements_helper.rb
@@ -1,0 +1,2 @@
+module MeasurementsHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,8 +1,9 @@
 class Item < ApplicationRecord
   belongs_to :item_category
   belongs_to :user
+  belongs_to :measurement
   has_many :watchitems
-  has_many :watchlist, :through => :watchitems
+  has_many :watchlists, :through => :watchitems
   has_many :requests
   has_many :orders, :through => :requests
 end

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -1,0 +1,2 @@
+class Measurement < ApplicationRecord
+end

--- a/app/models/measurement.rb
+++ b/app/models/measurement.rb
@@ -1,2 +1,3 @@
 class Measurement < ApplicationRecord
+    has_many :items
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,5 +1,4 @@
 class Request < ApplicationRecord
   belongs_to :item
   belongs_to :order
-  has_one :measurement, :through => :items
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,4 +1,5 @@
 class Request < ApplicationRecord
   belongs_to :item
   belongs_to :order
+  has_one :measurement, :through => :items
 end

--- a/app/views/measurements/_form.html.erb
+++ b/app/views/measurements/_form.html.erb
@@ -1,0 +1,22 @@
+<%= form_with(model: measurement, local: true) do |form| %>
+  <% if measurement.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(measurement.errors.count, "error") %> prohibited this measurement from being saved:</h2>
+
+      <ul>
+      <% measurement.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :unit %>
+    <%= form.text_field :unit %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/measurements/_measurement.json.jbuilder
+++ b/app/views/measurements/_measurement.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! measurement, :id, :unit, :created_at, :updated_at
+json.url measurement_url(measurement, format: :json)

--- a/app/views/measurements/edit.html.erb
+++ b/app/views/measurements/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Measurement</h1>
+
+<%= render 'form', measurement: @measurement %>
+
+<%= link_to 'Show', @measurement %> |
+<%= link_to 'Back', measurements_path %>

--- a/app/views/measurements/index.html.erb
+++ b/app/views/measurements/index.html.erb
@@ -1,0 +1,27 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Measurements</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Unit</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @measurements.each do |measurement| %>
+      <tr>
+        <td><%= measurement.unit %></td>
+        <td><%= link_to 'Show', measurement %></td>
+        <td><%= link_to 'Edit', edit_measurement_path(measurement) %></td>
+        <td><%= link_to 'Destroy', measurement, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Measurement', new_measurement_path %>

--- a/app/views/measurements/index.json.jbuilder
+++ b/app/views/measurements/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @measurements, partial: "measurements/measurement", as: :measurement

--- a/app/views/measurements/new.html.erb
+++ b/app/views/measurements/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Measurement</h1>
+
+<%= render 'form', measurement: @measurement %>
+
+<%= link_to 'Back', measurements_path %>

--- a/app/views/measurements/show.html.erb
+++ b/app/views/measurements/show.html.erb
@@ -1,0 +1,9 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Unit:</strong>
+  <%= @measurement.unit %>
+</p>
+
+<%= link_to 'Edit', edit_measurement_path(@measurement) %> |
+<%= link_to 'Back', measurements_path %>

--- a/app/views/measurements/show.json.jbuilder
+++ b/app/views/measurements/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "measurements/measurement", measurement: @measurement

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :measurements
   resources :charges
 
   resources :requests

--- a/db/migrate/20190731021239_change_quantity_type_in_requests.rb
+++ b/db/migrate/20190731021239_change_quantity_type_in_requests.rb
@@ -1,0 +1,5 @@
+class ChangeQuantityTypeInRequests < ActiveRecord::Migration[5.2]
+  def change
+    change_column :requests, :quantity, :float
+  end
+end

--- a/db/migrate/20190731023323_create_measurements.rb
+++ b/db/migrate/20190731023323_create_measurements.rb
@@ -1,0 +1,9 @@
+class CreateMeasurements < ActiveRecord::Migration[5.2]
+  def change
+    create_table :measurements do |t|
+      t.string :unit
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190731024032_add_measurement_to_items.rb
+++ b/db/migrate/20190731024032_add_measurement_to_items.rb
@@ -1,0 +1,5 @@
+class AddMeasurementToItems < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :items, :measurement, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_023323) do
+ActiveRecord::Schema.define(version: 2019_07_31_024032) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,7 +58,9 @@ ActiveRecord::Schema.define(version: 2019_07_31_023323) do
     t.float "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "measurement_id"
     t.index ["item_category_id"], name: "index_items_on_item_category_id"
+    t.index ["measurement_id"], name: "index_items_on_measurement_id"
     t.index ["user_id"], name: "index_items_on_user_id"
   end
 
@@ -162,6 +164,7 @@ ActiveRecord::Schema.define(version: 2019_07_31_023323) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "cities", "states"
   add_foreign_key "items", "item_categories"
+  add_foreign_key "items", "measurements"
   add_foreign_key "items", "users"
   add_foreign_key "locations", "cities"
   add_foreign_key "orders", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_30_090155) do
+ActiveRecord::Schema.define(version: 2019_07_31_021239) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -90,7 +90,7 @@ ActiveRecord::Schema.define(version: 2019_07_30_090155) do
     t.bigint "item_id"
     t.bigint "order_id"
     t.string "message"
-    t.integer "quantity"
+    t.float "quantity"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["item_id"], name: "index_requests_on_item_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_021239) do
+ActiveRecord::Schema.define(version: 2019_07_31_023323) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,12 @@ ActiveRecord::Schema.define(version: 2019_07_31_021239) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["city_id"], name: "index_locations_on_city_id"
+  end
+
+  create_table "measurements", force: :cascade do |t|
+    t.string "unit"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "orders", force: :cascade do |t|

--- a/test/controllers/measurements_controller_test.rb
+++ b/test/controllers/measurements_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class MeasurementsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @measurement = measurements(:one)
+  end
+
+  test "should get index" do
+    get measurements_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_measurement_url
+    assert_response :success
+  end
+
+  test "should create measurement" do
+    assert_difference('Measurement.count') do
+      post measurements_url, params: { measurement: { unit: @measurement.unit } }
+    end
+
+    assert_redirected_to measurement_url(Measurement.last)
+  end
+
+  test "should show measurement" do
+    get measurement_url(@measurement)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_measurement_url(@measurement)
+    assert_response :success
+  end
+
+  test "should update measurement" do
+    patch measurement_url(@measurement), params: { measurement: { unit: @measurement.unit } }
+    assert_redirected_to measurement_url(@measurement)
+  end
+
+  test "should destroy measurement" do
+    assert_difference('Measurement.count', -1) do
+      delete measurement_url(@measurement)
+    end
+
+    assert_redirected_to measurements_url
+  end
+end

--- a/test/fixtures/measurements.yml
+++ b/test/fixtures/measurements.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  unit: MyString
+
+two:
+  unit: MyString

--- a/test/models/measurement_test.rb
+++ b/test/models/measurement_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MeasurementTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/measurements_test.rb
+++ b/test/system/measurements_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class MeasurementsTest < ApplicationSystemTestCase
+  setup do
+    @measurement = measurements(:one)
+  end
+
+  test "visiting the index" do
+    visit measurements_url
+    assert_selector "h1", text: "Measurements"
+  end
+
+  test "creating a Measurement" do
+    visit measurements_url
+    click_on "New Measurement"
+
+    fill_in "Unit", with: @measurement.unit
+    click_on "Create Measurement"
+
+    assert_text "Measurement was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Measurement" do
+    visit measurements_url
+    click_on "Edit", match: :first
+
+    fill_in "Unit", with: @measurement.unit
+    click_on "Update Measurement"
+
+    assert_text "Measurement was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Measurement" do
+    visit measurements_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Measurement was successfully destroyed"
+  end
+end


### PR DESCRIPTION
Worked on resolving the bug of users not being able to specify what unit measurement they are setting the quantity of their product in. 
Problem fixed. We can now create a dropdown of measurement type for users selling items

- request table quantity field type changed to float
- measurement table added
- FK measurement in items table.
